### PR TITLE
Slash commands are now active and rolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@discordjs/builders": "^0.5.0",
         "canvas": "^2.6.1",
         "challonge-js": "^1.1.1",
         "discord.js": "13.1.0",
@@ -26,6 +27,10 @@
         "@types/mongodb": "^3.6.3",
         "@types/node": "^16.4.10",
         "@types/ws": "^7.4.5"
+      },
+      "engines": {
+        "node": "16.6.1",
+        "npm": "7.20.5"
       }
     },
     "node_modules/@discordjs/builders": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@discordjs/builders": "^0.5.0",
     "canvas": "^2.6.1",
     "challonge-js": "^1.1.1",
     "discord.js": "13.1.0",
@@ -31,5 +32,9 @@
     "@types/mongodb": "^3.6.3",
     "@types/node": "^16.4.10",
     "@types/ws": "^7.4.5"
+  },
+  "engines": {
+    "node": "16.6.1",
+    "npm": "7.20.5"
   }
 }

--- a/src/commands/convertMMtoMR.ts
+++ b/src/commands/convertMMtoMR.ts
@@ -29,6 +29,7 @@ export const transition: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     execute: async function (message: Message, client: Client, args: string[]) {
         let mmU: MMuser[] = await getAllColl("users");
         let temp = await getOneColl("tempstruct", "templatelist");

--- a/src/commands/exhibition/index.ts
+++ b/src/commands/exhibition/index.ts
@@ -13,6 +13,7 @@ export const duel: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         if (![message.mentions.users.values()]) {
             return message.reply("Please mention someone");
@@ -23,7 +24,8 @@ export const duel: Command = {
         }
 
         if (args.length < 2) {
-            return message.reply("Please use theme flag or template flag");
+            return message.reply("Please use theme flag or template flag. If you need help do the command `!duel" +
+                " -help`");
         }
 
         else if (args.length >= 3) {
@@ -44,7 +46,7 @@ export const duel: Command = {
         }
 
         if (ex.cooldowns.some(x => x.user === message.mentions.users.first()!.id)) {
-            return message.reply(`It hasn't been 5 mins for <@${message.mentions.users.first()!.id}`);
+            return message.reply(`It hasn't been 5 mins for ${message.mentions.users.first()!.username}`);
         }
 
         let m = message;
@@ -99,7 +101,7 @@ export const duel: Command = {
             ex = await getExhibition();
 
             let guild = client.guilds.cache.get(message.guild!.id)!;
-            let category = await guild!.channels.cache.find(c => c.name.toLowerCase() == "duels" && c.type == "GUILD_CATEGORY")!;
+            let category = await guild!.channels.cache.find(c => c.name.toLowerCase().includes("duels")  && c.type == "GUILD_CATEGORY")!;
 
             await guild?.channels
             .create(`${message.author.username}-vs-${message.mentions.users.first()?.username}`, {

--- a/src/commands/exhibition/utils.ts
+++ b/src/commands/exhibition/utils.ts
@@ -2,6 +2,7 @@ import type { Client, Message, TextChannel } from "discord.js";
 import { getExhibition, getMatch, updateExhibition, updateMatch } from "../../db";
 import type { Command } from "../../types";
 import { toHHMMSS } from "../util";
+import { MessageEmbed } from "discord.js";
 
 export const duelcheck: Command = {
     name: "duel -check",
@@ -12,6 +13,7 @@ export const duelcheck: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let ex = await getExhibition();
 
@@ -36,6 +38,7 @@ export const duelreload: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let match = await getMatch(message.channel.id);
         let channel = <TextChannel>await client.channels.cache.get(message.channel.id)!;
@@ -67,6 +70,7 @@ export const duelcooldownreset: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let ex = await getExhibition();
 
@@ -78,10 +82,60 @@ export const duelcooldownreset: Command = {
     }
 };
 
+export const duelHelp: Command = {
+    name: "duel -help",
+    description: "Duel's help menu",
+    group: "duels",
+    groupCommand: true,
+    owner: false,
+    admins: false,
+    mods: false,
+    slashCommand:false,
+    serverOnlyCommand:false,
+    async execute(message: Message, client: Client, args: string[]) {
+        let helpEmbed = new MessageEmbed()
+            .setColor("RANDOM")
+            .setTitle("Duel help menu")
+            .setDescription(
+                "Duels are a way to play matches with other people in this server."+
+                "\nAll you have to do is do the !duel command, and the bot will start a duel for you."+
+                "\nTo the person who is being mentioned, the bot will dm you, and just follow it's instructions."+
+                "You have a chance to duel others every 1h, with the bot dming you when you can."
+            )
+            .setFields(
+                {
+                    name: '`!duel @someone <theme | template>`',
+                    value: `Pass an theme or template flag, and you will get a random theme or template from our inventory.`,
+                },
+                {
+                    name: '`!duel -create`',
+                    value: `Create your duelist profile. If you played in a duel, this profile has already been made for you.`,
+                },
+                {
+                    name: '`!duel -stats <@mention>`',
+                    value: `Check out your duel statistics. Mention another user and you can see their stats.`,
+                },
+                {
+                    name: '`!duel -lb <points | ratio | loss | votes | all>`',
+                    value: `See how you rank with other duelist in your server. If no flag is passed, the lb sorts by wins.`,
+                },
+                {
+                    name:'`!resetcd`',
+                    value:'0_o'
+                }
+            )
+            .setTimestamp(new Date)
+        ;
+
+        return await message.reply({embeds:[helpEmbed]});
+    }
+};
+
 export default [
     duelcooldownreset,
     duelreload,
-    duelcheck
+    duelcheck,
+    duelHelp
 ].sort(function keyOrder(k1, k2) {
     if (k1.name < k2.name) return -1; else if (k1.name > k2.name) return 1; else return 0;
 });

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -14,6 +14,7 @@ export const help: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         if (args.length === 0) {
 

--- a/src/commands/imagecommands/contest.ts
+++ b/src/commands/imagecommands/contest.ts
@@ -24,6 +24,7 @@ export const contestSubmit: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (message.channel.type !== "DM") {
             return message
@@ -78,6 +79,7 @@ export const contestManager: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let doc: Contest = await getDoc("contest", "contest");
 
@@ -100,10 +102,10 @@ export const contestManager: Command = {
                     .setDescription("Entered with this image submission")
                     .setURL(winner.url)
                     .setColor(`#${(await getConfig()).colour}`)
-                    .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                        format: "webp",
-                        size: 512
-                    }))}`)
+                .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                format: "webp",
+                size: 512
+            }))}`)
                 ;
 
                 await channel.send({embeds:[em]});

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,9 +2,9 @@ import { Client, CommandInteraction, Message, MessageEmbed, MessageReaction, Use
 import type { Command } from "../types";
 import { help } from "./help";
 import { cancelmatch, splitmatch, startmatch, startsplit } from "./match";
-import { endmatch, forcevote, matchStats, matchList, reload_match } from "./match/utils";
+import { endmatch, forcevote, matchList, matchStats, reload_match } from "./match/utils";
 import { cancelqual, endqual, splitqual, startsplitqual } from "./quals";
-import { forcevote_qual, qual_result_sum, qual_stats, qual_winner, reload_qual } from "./quals/util";
+import { forcevote_qual, qual_result_sum, qual_stats, qual_winner, reload_qual, removeQualWinner } from "./quals/util";
 import { modqualsubmit, modsubmit, qualsubmit, submit, templateSubmission, themeSubmission } from "./submit";
 import * as b from "./tournament/index";
 import * as c from "./exhibition/index";
@@ -13,12 +13,11 @@ import * as e from "./jointcommands";
 import * as f from "./verification";
 import * as imageCommands from "./imagecommands/index";
 import * as level from "./levelsystem";
-import { manualverify } from "./verification";
 import { delay } from "./reminders";
 import { getConfig, updateConfig } from "../db";
 import { cmd } from "../index";
 import { transition } from "./convertMMtoMR";
-import { defaultSlashPermissions, sleep } from "./util";
+import { defaultSlashPermissions } from "./util";
 
 //@ts-ignore
 export const example: Command = {
@@ -28,9 +27,20 @@ export const example: Command = {
     owner: false,
     admins: false,
     mods: false,
+    slashCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
 
-    }
+    },
+    async slashCommandFunction(interaction: CommandInteraction, client: Client) {
+        if(!interaction.isCommand()) return;
+    },
+    slashCommandData:[
+        {
+            name: 'EXAMPLE',
+            description: 'An example!',
+        },
+    ],
+    slashCommandPermissions: defaultSlashPermissions
 };
 
 export const ping: Command = {
@@ -42,6 +52,7 @@ export const ping: Command = {
     admins: false,
     mods: false,
     slashCommand:true,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         message.channel.send({
             embeds:[
@@ -60,7 +71,6 @@ export const ping: Command = {
             .setColor(m.embeds![0]!.hexColor!);
             // Then It Edits the message with the ping variable embed that you created
             await m.edit({embeds: [embed]}).then(async m => {
-                await sleep(1)
                 let embed = new MessageEmbed()
                 .setTitle(`Your ping is ${ping} ms`)
                 .setImage("https://cdn.discordapp.com/attachments/722306381893599242/855600330405838849/catping.gif")
@@ -96,6 +106,7 @@ export const disableCommands: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let config = await getConfig();
 
@@ -126,6 +137,7 @@ export const enableCommands: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let config = await getConfig();
 
@@ -153,6 +165,7 @@ export const deleteSlashCommands: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let guild = await client.guilds.cache.get('719406444109103117')!
 
@@ -184,6 +197,7 @@ export const editConfig: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let config = await getConfig();
 
@@ -325,6 +339,7 @@ export default [
     forcevote,
     forcevote_qual,
     qual_winner,
+    removeQualWinner,
     splitmatch,
     cancelmatch,
     submit,
@@ -341,7 +356,6 @@ export default [
     matchStats,
     templateSubmission,
     themeSubmission,
-    manualverify
 ]
 .concat(b.default)
 .concat(c.default)

--- a/src/commands/jointcommands.ts
+++ b/src/commands/jointcommands.ts
@@ -16,6 +16,7 @@ export const pause: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let id = message.mentions.channels.first() ? message.mentions.channels.first()!.id : message.channel.id!;
         let channel = await <TextChannel>client.channels.cache.get(id);
@@ -50,6 +51,7 @@ export const cancel: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let id = message.mentions.channels.first() ? message.mentions.channels.first()!.id : message.channel.id!;
         let m = await getMatch(id)
@@ -76,6 +78,7 @@ export const end: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let id = message.mentions.channels.first() ? message.mentions.channels.first()!.id : message.channel.id!;
         let m = await getMatch(id)
@@ -101,6 +104,7 @@ export const search: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let id = (message.mentions?.users?.first()?.id || args[0] || message.author.id);
 
@@ -113,7 +117,16 @@ export const search: Command = {
         if (m !== undefined && q !== undefined) return message.reply(`You are in a Qualifier: <#${q._id}> & Match: <#${m._id}>`);
         if (m !== undefined) return message.reply(`The channel is <#${m._id}>`);
         if (q !== undefined) return message.reply(`The channel is <#${q._id}>`);
-        else return message.reply("You aren't in a match or qualifier.")
+
+        if(m === undefined) {
+            let username = (await client.users.fetch(id)).username.toLowerCase()
+            let channelID = message.guild!.channels.cache.find(x => x.name.toLowerCase().includes(username))?.id
+
+            if(channelID) return message.reply(`The channel is <#${channelID}>`)
+
+        }
+
+        return message.reply("Not in a match or qualifier.")
     }
 };
 
@@ -125,6 +138,7 @@ export const cycleRestart: Command = {
     admins: true,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (![
             "true",
@@ -181,6 +195,7 @@ export const autoCommand: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let date = args[0];
         let hours = args[1];

--- a/src/commands/levelsystem.ts
+++ b/src/commands/levelsystem.ts
@@ -18,6 +18,7 @@ export const level: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let imgurl = args[0] ?
             (

--- a/src/commands/match/index.ts
+++ b/src/commands/match/index.ts
@@ -12,6 +12,7 @@ export const startmatch: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     execute: async function (message: Message, client: Client, args: string[]) {
         if ([...message.mentions.users.values()].length < 2) return message.reply("Please mention the users");
 
@@ -47,27 +48,30 @@ export const startmatch: Command = {
         let em = new MessageEmbed();
 
         let temps: string[] = [];
+        let temp = "";
 
         if (m.temp.istheme) {
             temps = (await getThemes()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)];
 
             em.setTitle(`Theme for ${c.name}`)
-            .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+            .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                 format: "webp",
                 size: 512
             }))}`)
-            .setDescription(temps[Math.floor(Math.random() * temps.length)]);
+            .setDescription(temp);
         }
 
         else {
             temps = (await getTemplatedB()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)];
 
             em.setTitle(`Template for ${c.name}`)
-            .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+            .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                 format: "webp",
                 size: 512
             }))}`)
-            .setImage(temps[Math.floor(Math.random() * temps.length)]);
+            .setImage(temp);
         }
 
         let msg = await c
@@ -96,17 +100,19 @@ export const startmatch: Command = {
             if (m.temp.istheme) {
                 temps = (await getThemes()).list;
 
+                temp = temps[Math.floor(Math.random() * temps.length)]
+
                 let eem = new MessageEmbed()
-                .setTitle(`Theme for ${c.name}`)
-                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                    format: "webp",
-                    size: 512
-                }))}`)
-                .setDescription(temps[Math.floor(Math.random() * temps.length)])
-                .setColor("PURPLE");
+                    .setTitle(`Theme for ${c.name}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                        format: "webp",
+                        size: 512
+                    }))}`)
+                    .setDescription(temp)
+                    .setColor("PURPLE");
 
                 await msg.edit({
-                    embeds:[
+                    embeds: [
                         eem
                     ]
                 });
@@ -115,17 +121,19 @@ export const startmatch: Command = {
             else {
                 temps = (await getTemplatedB()).list;
 
+                temp = temps[Math.floor(Math.random() * temps.length)]
+
                 let eem = new MessageEmbed()
-                .setTitle(`Template for ${c.name}`)
-                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                    format: "webp",
-                    size: 512
-                }))}`)
-                .setImage(temps[Math.floor(Math.random() * temps.length)])
-                .setColor("PURPLE");
+                    .setTitle(`Template for ${c.name}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                        format: "webp",
+                        size: 512
+                    }))}`)
+                    .setImage(temp)
+                    .setColor("PURPLE");
 
                 await msg.edit({
-                    embeds:[
+                    embeds: [
                         eem
                     ]
                 });
@@ -136,11 +144,11 @@ export const startmatch: Command = {
         disapprove.on('collect', async () => {
             msg.reactions.cache.forEach(reaction => reaction.users.remove(message.author.id));
             message.channel.send({
-                embeds:[
+                embeds: [
                     new MessageEmbed()
                         .setColor("RED")
                         .setTitle("FAILED")
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+                        .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                             format: "webp",
                             size: 512
                         }))}`)
@@ -155,10 +163,10 @@ export const startmatch: Command = {
             msg.reactions.cache.forEach(reaction => reaction.users.remove(message.author.id));
 
             if (m.temp.istheme) {
-                m.temp.link = msg.embeds[0].description!;
+                m.temp.link = temp;
             }
             else {
-                m.temp.link = msg.embeds[0].image?.url!;
+                m.temp.link = temp;
             }
 
             await insertMatch(m).then(async a => {
@@ -172,31 +180,25 @@ export const startmatch: Command = {
             for (let us of [...message.mentions.users.values()]) {
                 if (m.temp.istheme) {
                     await us.send("Your theme is " + m.temp.link);
-                    await us.send({
-                        embeds:[
-                            new MessageEmbed()
-                                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                                    format: "webp",
-                                    size: 512
-                                }))}`)
-                                .setColor(`#${(await getConfig()).colour}`)
-                                .setDescription(`You have 45 mins to complete your meme\n` + `Use \`!submit\` to submit to submit.`)
-                        ]
-                    });
                 }
 
                 else {
                     await us.send("Your template is " + m.temp.link);
-                    await us.send({embeds:[
-                            new MessageEmbed()
-                                .setColor(`#${(await getConfig()).colour}`)
-                                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                                    format: "webp",
-                                    size: 512
-                                }))}`)
-                                .setDescription(`You have 45 mins to complete your meme\n` + `Use \`!submit\` to submit to submit.`)
-                        ]});
                 }
+
+                await us.send({
+                    embeds: [
+                        new MessageEmbed()
+                            .setColor(`#${(await getConfig()).colour}`)
+                            .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                                format: "webp",
+                                size: 512
+                            }))}`)
+                            .setDescription(`You have 45 mins to complete your meme\n` + `Use \`!submit\` to submit to submit.`)
+                    ]
+                });
+
+
 
                 await insertReminder({
                     _id: us.id, mention: "", channel: "", type: "meme", time: [
@@ -207,21 +209,26 @@ export const startmatch: Command = {
                 });
             }
 
+            try {
+                msg = await msg.fetch(true)
+                if(msg) await msg.delete()
+            } catch {
+                console.log("failed")
+            }
+
             return await message.channel.send({
-                embeds:[
+                embeds: [
                     new MessageEmbed()
                         .setTitle(`Match between ${[...message.mentions.users.values()][0].username} & ${[...message.mentions.users.values()][1].username}`)
                         .setColor("#d7be26")
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+                        .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                             format: "webp",
                             size: 512
                         }))}`)
                         .setDescription(`<@${[...message.mentions.users.values()][0].id}> and <@${[...message.mentions.users.values()][1].id}>, you have 45 mins to submit your memes\n Contact admins if you have an issue.`)
                         .setTimestamp()
                 ]
-            }).then(async () => {
-                await msg.delete().catch()
-            });
+            })
         });
     }
 };
@@ -234,6 +241,7 @@ export const splitmatch: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if ([...message.mentions.users.values()].length < 2) return message.reply("Please mention the users");
 
@@ -265,31 +273,35 @@ export const splitmatch: Command = {
             m.temp.istheme = true;
         }
 
-        let c: TextChannel = <TextChannel>await client.channels.fetch(await message.guild!.channels.cache.find(x => x.name.toLowerCase() === "mod-bot-spam")!.id);
+        // let c: TextChannel = <TextChannel>await client.channels.fetch(await message.guild!.channels.cache.find(x => x.name.toLowerCase() === "mod-bot-spam")!.id);
+        let c: TextChannel = <TextChannel>await client.channels.fetch("722616679280148504");
         let em = new MessageEmbed();
 
         let temps: string[] = [];
+        let temp = "";
 
         if (m.temp.istheme) {
             temps = (await getThemes()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)]
 
             em.setTitle(`Theme for ${c.name}`)
-            .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+            .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                 format: "webp",
                 size: 512
             }))}`)
-            .setDescription(temps[Math.floor(Math.random() * temps.length)]);
+            .setDescription(temp);
         }
 
         else {
             temps = (await getTemplatedB()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)]
 
             em.setTitle(`Template for ${c.name}`)
-            .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+            .setFooter("MemeRoyale#3101", `${((await client.users.fetch("722303830368190485"))!.displayAvatarURL({
                 format: "webp",
                 size: 512
             }))}`)
-            .setImage(temps[Math.floor(Math.random() * temps.length)]);
+            .setImage(temp);
         }
 
         let msg = await c
@@ -300,14 +312,9 @@ export const splitmatch: Command = {
             ]
         });
 
-        try {
-            await msg.react("✅");
-            await msg.react("❌");
-            await msg.react('🌀');
-        } catch (e) {
-            await message.channel.send(e.stack)
-            await message.channel.send(e.message)
-        }
+        await msg.react("✅");
+        await msg.react("❌");
+        await msg.react('🌀');
 
         const approveFilter = (reaction: MessageReaction, user:User) => reaction.emoji.name === '✅' && !user.bot;
         const disapproveFilter = (reaction: MessageReaction, user:User) => reaction.emoji.name === '❌' && !user.bot;
@@ -323,14 +330,16 @@ export const splitmatch: Command = {
             if (m.temp.istheme) {
                 temps = (await getThemes()).list;
 
+                temp = temps[Math.floor(Math.random() * temps.length)];
+
                 let eem = new MessageEmbed()
-                .setTitle(`Theme for ${c.name}`)
-                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                    format: "webp",
-                    size: 512
-                }))}`)
-                .setDescription(temps[Math.floor(Math.random() * temps.length)])
-                .setColor("PURPLE");
+                    .setTitle(`Theme for ${c.name}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                        format: "webp",
+                        size: 512
+                    }))}`)
+                    .setDescription(temp)
+                    .setColor("PURPLE");
 
                 try {
                     await msg.edit({
@@ -346,15 +355,16 @@ export const splitmatch: Command = {
 
             else {
                 temps = (await getTemplatedB()).list;
+                temp = temps[Math.floor(Math.random() * temps.length)]
 
                 let eem = new MessageEmbed()
-                .setTitle(`Template for ${c.name}`)
-                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                    format: "webp",
-                    size: 512
-                }))}`)
-                .setImage(temps[Math.floor(Math.random() * temps.length)])
-                .setColor("PURPLE");
+                    .setTitle(`Template for ${c.name}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                        format: "webp",
+                        size: 512
+                    }))}`)
+                    .setImage(temp)
+                    .setColor("PURPLE");
 
                 try {
                     await msg.edit({
@@ -375,10 +385,10 @@ export const splitmatch: Command = {
             randomize.stop("User failed to choose")
             msg.reactions.cache.forEach(reaction => reaction.users.remove(message.author.id));
             return message.channel.send({
-                embeds:[
+                embeds: [
                     new MessageEmbed()
                         .setColor("RED")
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
+                        .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
                             format: "webp",
                             size: 512
                         }))}`)
@@ -399,13 +409,13 @@ export const splitmatch: Command = {
             }
 
             if (m.temp.istheme) {
-                m.temp.link = msg.embeds[0].description!;
+                m.temp.link = temp;
             }
             else {
-                m.temp.link = msg.embeds[0].image?.url!;
+                m.temp.link = temp;
             }
 
-            await insertMatch(m).then(async a => {
+            await insertMatch(m).then(async () => {
                 let c = await (<TextChannel>client.channels.cache.get("854930976974700554"));
                 let cc = await (<TextChannel>client.channels.cache.get(m._id));
                 c.send(`<#${m._id}>/${cc.name} template is ${m.temp.link}`);
@@ -413,22 +423,15 @@ export const splitmatch: Command = {
             await createProfileatMatch([...message.mentions.users.values()][0].id);
             await createProfileatMatch([...message.mentions.users.values()][1].id);
 
-            try {
-                await msg.delete();
-            } catch (e) {
-                // await message.channel.send(e.stack)
-                // await message.channel.send(e.message)
-            }
-
-            return await message.channel.send({
+            await message.channel.send({
                 embeds:[
                     new MessageEmbed()
                         .setTitle(`Match between ${[...message.mentions.users.values()][0].username} & ${[...message.mentions.users.values()][1].username}`)
                         .setColor("#d7be26")
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                            format: "webp",
-                            size: 512
-                        }))}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                format: "webp",
+                size: 512
+            }))}`)
                         .setDescription(`<@${[...message.mentions.users.values()][0].id}> and <@${[...message.mentions.users.values()][1].id}>, your match has been split.\nYou must complete your portion with given round\n Contact admins if you have an issue.`)
                         .setTimestamp()
                 ]
@@ -436,6 +439,14 @@ export const splitmatch: Command = {
                 await m.react('🅰️');
                 await m.react('🅱️');
             });
+
+            try {
+                await msg.delete();
+            } catch (e) {
+                console.log("error deleting fuck my asshole")
+            }
+
+            return;
 
         });
     }
@@ -449,6 +460,7 @@ export const startsplit: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         try {
             if ([...message.mentions.users.values()].length === 0 && args.length === 0) return message.reply("Please mention the user.");
@@ -478,10 +490,10 @@ export const startsplit: Command = {
                 embeds:[
                     new MessageEmbed()
                         .setColor(`#${(await getConfig()).colour}`)
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                            format: "webp",
-                            size: 512
-                        }))}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                format: "webp",
+                size: 512
+            }))}`)
                         .setDescription(`<@${e.userid}> your match has been split.\n` + `You have 45 mins to complete your meme\n` + `Use \`!submit\` to submit to submit each image seperately`)
                 ]
             });
@@ -508,10 +520,10 @@ export const startsplit: Command = {
                 embeds:[
                     new MessageEmbed()
                         .setColor(`#${(await getConfig()).colour}`)
-                        .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                            format: "webp",
-                            size: 512
-                        }))}`)
+                    .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                format: "webp",
+                size: 512
+            }))}`)
                         .setDescription(`<@${e.userid}> your match has been split.\n`
                             + `You have 45 mins to complete your meme\n`
                             + `Use \`!submit\` to submit to submit each image seperately`)
@@ -531,6 +543,7 @@ export const cancelmatch: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         if ([...message.mentions.channels.values()].length === 1) {

--- a/src/commands/match/utils.ts
+++ b/src/commands/match/utils.ts
@@ -12,6 +12,7 @@ export const reload_match: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         let match = await getMatch(message.channel.id);
@@ -48,6 +49,7 @@ export const endmatch: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         let match = await getMatch(message.channel.id);
@@ -67,6 +69,7 @@ export const forcevote: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         let match = await getMatch(message.channel.id);
@@ -88,6 +91,7 @@ export const matchList: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let list: MatchList = await getDoc('config', "matchlist");
         let page: number = parseInt(args[0]) || 1;
@@ -130,6 +134,7 @@ export const matchStats: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (!message.mentions.channels.first()) {
             return message.reply("Please mention channel");

--- a/src/commands/quals/background.ts
+++ b/src/commands/quals/background.ts
@@ -308,7 +308,7 @@ async function matchResults(client: Client, q: Qual) {
         }).then(async message => {
             let t = channel.topic?.split(" ");
 
-            if (t?.join("").toLocaleLowerCase() === "round1" || !t) {
+            if (t?.join("").toLocaleLowerCase() === "round1" || t?.join("").toLocaleLowerCase() === "qualifierround" || !t) {
                 await channel.setTopic(message.id);
                 t = [];
                 let string = "";

--- a/src/commands/quals/index.ts
+++ b/src/commands/quals/index.ts
@@ -11,6 +11,7 @@ export const splitqual: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if ([...message.mentions.users.values()].length > 6) return message.reply("Please mention no more than 6 users.");
         if ([...message.mentions.users.values()].length < 3) return message.reply("Please mention at least 3 users.");
@@ -40,19 +41,22 @@ export const splitqual: Command = {
         let em = new MessageEmbed();
 
         let temps: string[] = [];
+        let temp = "";
 
         if (q.temp.istheme) {
             temps = (await getThemes()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)]
 
             em.setTitle(`Theme for ${c.name}`)
-            .setDescription(temps[Math.floor(Math.random() * temps.length)]);
+            .setDescription(temp);
         }
 
         else {
             temps = (await getTemplatedB()).list;
+            temp = temps[Math.floor(Math.random() * temps.length)]
 
             em.setTitle(`Template for ${c.name}`)
-            .setImage(temps[Math.floor(Math.random() * temps.length)]);
+            .setImage(temp);
         }
 
         let msg = await c
@@ -81,10 +85,11 @@ export const splitqual: Command = {
 
             if (q.temp.istheme) {
                 temps = (await getThemes()).list;
+                temp = temps[Math.floor(Math.random() * temps.length)]
 
                 let eem = new MessageEmbed()
                 .setTitle(`Theme for ${c.name}`)
-                .setDescription(temps[Math.floor(Math.random() * temps.length)])
+                .setDescription(temp)
                 .setColor("PURPLE");
 
                 await msg.edit({
@@ -96,10 +101,11 @@ export const splitqual: Command = {
 
             else {
                 temps = (await getTemplatedB()).list;
+                temp = temps[Math.floor(Math.random() * temps.length)]
 
                 let eem = new MessageEmbed()
                 .setTitle(`Template for ${c.name}`)
-                .setImage(temps[Math.floor(Math.random() * temps.length)])
+                .setImage(temp)
                 .setColor("PURPLE");
 
                 await msg.edit({
@@ -132,10 +138,10 @@ export const splitqual: Command = {
             msg.reactions.cache.forEach(reaction => reaction.users.remove(message.author.id));
 
             if (q.temp.istheme) {
-                q.temp.link = msg.embeds[0].description!;
+                q.temp.link = temp;
             }
             else {
-                q.temp.link = msg.embeds[0].image?.url!;
+                q.temp.link = temp;
             }
 
             await insertQual(q).then(async a => {
@@ -181,6 +187,7 @@ export const startsplitqual: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         try {
             if ([...message.mentions.users.values()].length === 0 && args.length === 0) return message.reply("Please mention the user.");
@@ -203,7 +210,7 @@ export const startsplitqual: Command = {
 
             (await client.users.cache.get(e.userid))!
                 .send({
-                    content:`This is your ${q.temp.istheme ? "theme: " : "template: "}`,
+                    content:`This is your ${q.temp.istheme ? "theme: " : "template: "} ${q.temp.link}`,
                     embeds:[
                         new MessageEmbed()
                             .setColor(`#${(await getConfig()).colour}`)
@@ -253,6 +260,7 @@ export const cancelqual: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         if ([...message.mentions.channels.values()].length === 1) {
@@ -291,6 +299,7 @@ export const endqual: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let m = await getQual(message.channel.id);
         m.votetime = (Math.floor(Math.floor(Date.now() / 1000) / 60) * 60) - 7200;

--- a/src/commands/quals/util.ts
+++ b/src/commands/quals/util.ts
@@ -11,6 +11,7 @@ export const reload_qual: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         let match = await getQual(message.channel.id);
@@ -45,6 +46,7 @@ export const qual_stats: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (!message.mentions.channels.first()) {
             return message.reply("Please mention channel");
@@ -90,6 +92,7 @@ export const qual_result_sum: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         if (args.length <= 1 && args.length >= 2) return message.reply("Please supply two msg ids.");
@@ -117,13 +120,14 @@ export const qual_result_sum: Command = {
 };
 
 export const forcevote_qual: Command = {
-    name: "forcevote-match",
+    name: "forcevote-qual",
     description: "This will force the voting portion of a match to come.",
-    group: "match",
+    group: "quals",
     owner: false,
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         // let match = await getQual(message.channel.id)
@@ -137,47 +141,6 @@ export const forcevote_qual: Command = {
 
     }
 };
-
-// export const search: Command = {
-//     name: "search",
-//     description: "!creategroup #Amount in each group",
-//     group: "tournament-manager",
-//     owner: false,
-//     admins: false,
-//     mods: false,
-//     async execute(message: Message, client: Client, args: string[]) {
-//         let signup: QualList = await getDoc("config", "quallist");
-//         let id = (message.mentions?.users?.first()?.id || args[0] || message.author.id);
-//         if (!id) return message.reply("invaild input. Please use User ID or a User mention");
-//
-//         //let name = await (await message.guild!.members.cache.get(id))!.nickname || await (await
-//         // client.users.fetch(id)).username
-//         if (message.member!.roles.cache.has('719936221572235295')) {
-//             for (let i = 0; i < signup.users.length; i++) {
-//
-//                 if (signup.users[i].includes(id)) {
-//                     return await message.reply(`This person is in <#${message.guild!.channels.cache.find(channel => channel.name === `group-${i + 1}`)!.id}>`);
-//                 }
-//             }
-//             return message.reply("They are not in a group");
-//         }
-//
-//         else {
-//             if (id !== message.author.id) {
-//                 return message.reply("You don't have those premissions");
-//             }
-//             else {
-//                 for (let i = 0; i < signup.users.length; i++) {
-//
-//                     if (signup.users[i].includes(id)) {
-//                         return await message.reply(`You are in <#${message.guild!.channels.cache.find(channel => channel.name === `group-${i + 1}`)!.id}>`);
-//                     }
-//                 }
-//                 return message.reply("They are not in a group");
-//             }
-//         }
-//     }
-// };
 
 export async function QualifierResults(channel: TextChannel, client: Client, ids: string[]) {
     let msgArr: Message[] = [];
@@ -243,6 +206,7 @@ export const qual_winner: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[], owner: "2", silentargs: string[]) {
         let ids: string[] = ([...message.mentions.users.values()].map(a => a.id).length >= 1 ? [...message.mentions.users.values()].map(a => a.id) : args);
         let list: MatchList = await getDoc('config', "matchlist");
@@ -281,6 +245,42 @@ export const qual_winner: Command = {
                 message.channel.send(`<@${silentargs[0]}>, Added users.`);
                 return;
             }
+        }
+    }
+};
+
+export const removeQualWinner: Command = {
+    name: "rqw",
+    description: "!rqw <@mentions>",
+    group: "tournament-manager",
+    owner: false,
+    admins: false,
+    mods: true,
+    slashCommand:false,
+    serverOnlyCommand:true,
+    async execute(message: Message, client: Client, args: string[], owner: "2", silentargs: string[]) {
+        let ids: string[] = ([...message.mentions.users.values()].map(a => a.id).length >= 1 ? [...message.mentions.users.values()].map(a => a.id) : args);
+        let list: MatchList = await getDoc('config', "matchlist");
+
+        if (list) {
+            let index = list.users.indexOf(ids[0]);
+
+            if (index === -1) return message.reply("User is not in list");
+
+            list.users.splice(index, 1)
+            await updateDoc('config', list._id, list);
+
+            try{
+                let u = await getProfile(ids[0]);
+                u.wins -= 1;
+                u.points -= 25;
+                await updateProfile(u);
+            } catch {
+                console.log("No profile.")
+            }
+
+            message.channel.send(`<@${message.author.id}>, Removed <@${ids[0]}>.`);
+            return;
         }
     }
 };

--- a/src/commands/reminders.ts
+++ b/src/commands/reminders.ts
@@ -116,6 +116,7 @@ export const delay: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let reminder = await getReminder(await message.mentions.channels.first()!.id);
         if ([message.mentions.channels.keys()].length === 0) {

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -11,6 +11,7 @@ export const submit: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
 
         if (message.channel.type !== "DM") {
@@ -144,6 +145,7 @@ export const qualsubmit: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         if (message.channel.type !== "DM") {
             return message
@@ -264,6 +266,7 @@ export const modsubmit: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         let m = await getMatch(message.mentions.channels.first()!.id);
@@ -351,6 +354,7 @@ export const modqualsubmit: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (message.content.includes("imgur")) {
             return message.reply("You can't submit imgur links");
@@ -443,6 +447,7 @@ export const templateSubmission: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let channel = <TextChannel>client.channels.cache.get("722291683030466621");
 
@@ -524,6 +529,7 @@ export const themeSubmission: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let channel = <TextChannel>client.channels.cache.get("722291683030466621");
 

--- a/src/commands/tournament/challonge.ts
+++ b/src/commands/tournament/challonge.ts
@@ -1,24 +1,216 @@
-import { Client, Message, MessageEmbed } from "discord.js";
+import { Client, CommandInteraction, GuildChannel, Message, MessageEmbed } from "discord.js";
 import { deleteReminder, getDoc, insertReminder, updateDoc } from "../../db";
 import type { Command, MatchList, QualList } from "../../types";
 import { matchcard } from "../match/utils";
-import { sleep } from "../util";
+import { commissionerDefaultSlashPermissions, refDefaultSlashPermissions, sleep } from "../util";
 
 const challonge = require("challonge-js");
 
 export const matchchannelcreate: Command = {
     name: "channelcreate",
-    description: "!channelcreate <round number> <time in hours to complete>",
+    description: "!channelcreate <-qual> <round number> <time in hours to complete>",
     group: "tournament-manager",
     owner: false,
     admins: false,
     mods: true,
-    slashCommand:false,
+    slashCommand:true,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
-        if (!args) {
-            return message.reply("Please input round number and how long the round is!");
+        if(!args) return message.reply("Please pass in arguments.")
+
+        if(args[0] === "-qual") {
+            let time = parseInt(args[2]);
+            if (!time) return message.channel.send("Please state how long this qualifier will be");
+            let qlist: QualList = await getDoc("config", "quallist");
+
+            for (let i = 0; i < qlist.users.length; i++) {
+
+                if (qlist.users[i].length > 0) {
+
+                    let category = await message.guild!.channels.cache.find(c => c.name == "qualifiers" && c.type == "GUILD_CATEGORY");
+
+                    await message.guild!.channels.create(`Group ${i + 1}`, {
+                        type: 'GUILD_TEXT', topic: `Round ${args[0]}`, parent: category!.id
+                    })
+                        .then(async channel => {
+                            let string = "";
+
+                            for (let u of qlist.users[i]) {
+                                string += `<@${u}> `;
+                            }
+
+                            await insertReminder({
+                                _id: channel.id, mention: string, channel: channel.id, type: "match", time: [
+                                    172800,
+                                    165600,
+                                    129600,
+                                    86400
+                                ], timestamp: Math.floor(Date.now() / 1000), basetime: 172800
+                            });
+                            await channel.send(`${string}, Portion ${args[1]} has begun, and you have ${time}h to complete it. Contact a ref to begin your portion!`);
+                        });
+                }
+
+            }
+
+            return message.reply("Made all Qualifier Channels");
         }
+
         else {
+            if (!args) {
+                return message.reply("Please input round number and how long the round is!");
+            }
+            else {
+
+                let names: { str: string, id: string }[] = [];
+
+                let match: MatchList = await getDoc("config", "matchlist");
+
+                for (let i = 0; i < match.users.length; i++) {
+                    //console.log(match.users[i])
+                    try {
+                        let name = (await (await client.users.fetch(match.users[i])).username);
+                        names.push({
+                            str: name, id: (match.users[i])
+                        });
+                    } catch {
+                        message.channel.send(`<@${match.users[i]}>/${match.users[i]} is fucked`);
+                    }
+                    //names.concat([((await (await message.guild!.members.fetch(i)).nickname) || await (await
+                    // disclient.users.fetch(i)).username), i])
+                }
+
+                const cclient = challonge.createClient({
+                    apiKey: process.env.CHALLONGE
+                });
+
+                let matchlist: MatchList = await getDoc("config", "matchlist");
+
+                //@ts-ignore
+                await cclient.matches.index({
+                    id: matchlist.url, callback: async (err: any, data: any) => {
+                        if (err) console.log(err);
+
+                        for (let d of data) {
+                            if (d.match.round === parseInt(args[0])) {
+                                if (d.match.player1Id === null || d.match.player2Id === null) continue;
+
+                                let channelstringname: string = "", name1: string = "", name2: string = "";
+
+                                cclient.participants.index({
+                                    id: matchlist.url, callback: async (err: any, data: any) => {
+                                        if (err) console.log(err);
+
+                                        for (let x = 0; x < data.length; x++) {
+                                            if (data[x].participant.id === d.match.player1Id) {
+                                                //channelstringname += data[x].participant.name.substring(0, 10)
+                                                name1 = data[x].participant.name;
+                                            }
+
+                                            if (data[x].participant.id === d.match.player2Id) {
+                                                name2 = data[x].participant.name;
+                                            }
+                                        }
+
+                                        if (name2.length > 0 && name1.length > 0) {
+                                            channelstringname += name1.substring(0, 10) + "-vs-" + name2.substring(0, 10);
+                                        }
+                                        let category = await message.guild!.channels.cache.find(c => c.name == "matches" && c.type == "GUILD_CATEGORY")!;
+                                        await message.guild!.channels.create(channelstringname, {
+                                            type: 'GUILD_TEXT', topic: `48h to complete`,
+                                            position:d.match.id, parent:category.id})
+                                            .then(async channel => {
+
+                                                // if (!category) throw new Error("Category channel does not exist");
+                                                // await channel.setParent(category.id);
+                                                // await channel.lockPermissions();
+
+                                                await insertReminder({
+                                                    _id: channel.id,
+                                                    mention: `<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}>`,
+                                                    channel: channel.id,
+                                                    type: "match",
+                                                    time: [
+                                                        172800,
+                                                        165600,
+                                                        129600,
+                                                        86400
+                                                    ],
+                                                    timestamp: Math.floor(Date.now() / 1000),
+                                                    basetime: 172800
+                                                });
+                                                try{
+                                                    let image = await matchcard(client, channel.id, [
+                                                        names.find(x => x.str === name1)!.id,
+                                                        names.find(x => x.str === name2)!.id
+                                                    ]).catch();
+                                                    await sleep(2)
+                                                    await channel
+                                                        .send({
+                                                            content:`<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}> You have ${args[1]}h to complete this match. Contact a ref to begin, you may also split your match`,
+                                                            files:[
+                                                                image
+                                                            ]
+                                                        });
+                                                } catch (error) {
+                                                    await message.channel.send(`${channelstringname} no Match card`)
+                                                    await message.channel.send(error.stack)
+                                                    await message.channel.send(error.message)
+                                                }
+
+                                            });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                });
+            }
+            return message.reply("Made all Match Channels");
+        }
+    },
+    async slashCommandFunction(interaction: CommandInteraction, client: Client) {
+        if(!interaction.isCommand()) return;
+
+        if (interaction.options.getSubcommand() === "quals") {
+            let time = interaction.options!.getInteger("time")!;
+            if (!time) return await interaction.editReply("Please state how long this qualifier will be");
+            let qualList: QualList = await getDoc("config", "quallist");
+
+            for (let i = 0; i < qualList.users.length; i++) {
+
+                if (qualList.users[i].length > 0) {
+
+                    let category = await interaction.guild!.channels.cache.find(c => c.name.toLowerCase() === "qualifiers" && c.type == "GUILD_CATEGORY");
+
+                    await interaction.guild!.channels.create(`Group ${i + 1}`, {
+                        type: 'GUILD_TEXT', topic: `Qualifier Round`, parent: category!.id
+                    })
+                        .then(async channel => {
+                            let string = "";
+
+                            for (let u of qualList.users[i]) {
+                                string += `<@${u}> `;
+                            }
+
+                            await insertReminder({
+                                _id: channel.id, mention: string, channel: channel.id, type: "match", time: [
+                                    172800,
+                                    165600,
+                                    129600,
+                                    86400
+                                ], timestamp: Math.floor(Date.now() / 1000), basetime: 172800
+                            });
+                            await channel.send(`${string}, Portion ${interaction.options!.getInteger("portion")} has begun, and you have ${time}h to complete it. Contact a ref to begin your portion!`);
+                        });
+                }
+
+            }
+
+            return await interaction.editReply("Made all Qualifier Channels");
+        }
+
+        if (interaction.options.getSubcommand() === "match") {
 
             let names: { str: string, id: string }[] = [];
 
@@ -27,15 +219,13 @@ export const matchchannelcreate: Command = {
             for (let i = 0; i < match.users.length; i++) {
                 //console.log(match.users[i])
                 try {
-                    let name = (await (await client.users.fetch(match.users[i])).username);
+                    let name = (await client.users.fetch(match.users[i])).username;
                     names.push({
                         str: name, id: (match.users[i])
                     });
                 } catch {
-                    message.channel.send(`<@${match.users[i]}>/${match.users[i]} is fucked`);
+                    console.log(`<@${match.users[i]}>/${match.users[i]} is fucked`);
                 }
-                //names.concat([((await (await message.guild!.members.fetch(i)).nickname) || await (await
-                // disclient.users.fetch(i)).username), i])
             }
 
             const cclient = challonge.createClient({
@@ -50,7 +240,8 @@ export const matchchannelcreate: Command = {
                     if (err) console.log(err);
 
                     for (let d of data) {
-                        if (d.match.round === parseInt(args[0])) {
+                        console.log(typeof data)
+                        if (d.match.round === interaction.options!.getInteger("round")) {
                             if (d.match.player1Id === null || d.match.player2Id === null) continue;
 
                             let channelstringname: string = "", name1: string = "", name2: string = "";
@@ -58,23 +249,6 @@ export const matchchannelcreate: Command = {
                             cclient.participants.index({
                                 id: matchlist.url, callback: async (err: any, data: any) => {
                                     if (err) console.log(err);
-
-                                    // while (channelstringname.length === 0 && name1.length === 0 && name2.length === 0) {
-                                    //     for (let x = 0; x < data.length; x++) {
-                                    //         if (data[x].participant.id === d.match.player1Id) {
-                                    //             //channelstringname += data[x].participant.name.substring(0, 10)
-                                    //             name1 = data[x].participant.name;
-                                    //         }
-                                    //
-                                    //         if (data[x].participant.id === d.match.player2Id) {
-                                    //             name2 = data[x].participant.name;
-                                    //         }
-                                    //     }
-                                    //
-                                    //     if (name2.length > 0 && name1.length > 0) {
-                                    //         channelstringname += name1.substring(0, 10) + "-vs-" + name2.substring(0, 10);
-                                    //     }
-                                    // }
 
                                     for (let x = 0; x < data.length; x++) {
                                         if (data[x].participant.id === d.match.player1Id) {
@@ -90,59 +264,110 @@ export const matchchannelcreate: Command = {
                                     if (name2.length > 0 && name1.length > 0) {
                                         channelstringname += name1.substring(0, 10) + "-vs-" + name2.substring(0, 10);
                                     }
-                                    let category = await message.guild!.channels.cache.find(c => c.name == "matches" && c.type == "GUILD_CATEGORY")!;
-                                    await message.guild!.channels.create(channelstringname, {
-                                        type: 'GUILD_TEXT', topic: `48h to complete`,
-                                    position:d.match.id, parent:category.id})
-                                    .then(async channel => {
+                                    let category:GuildChannel
+                                        = <GuildChannel>await interaction.guild!.channels.cache.find(c => c.name.toLowerCase() === "matches" && c.type == "GUILD_CATEGORY")!;
+                                    await interaction.guild!.channels.create(channelstringname, {
+                                        type: 'GUILD_TEXT', topic: `${interaction.options!.getInteger("time")}h to complete`,
+                                        position:d.match.id, parent:category.id})
+                                        .then(async channel => {
 
-                                        // if (!category) throw new Error("Category channel does not exist");
-                                        // await channel.setParent(category.id);
-                                        // await channel.lockPermissions();
+                                            try {
+                                                await insertReminder({
+                                                    _id: channel.id,
+                                                    mention: `<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}>`,
+                                                    channel: channel.id,
+                                                    type: "match",
+                                                    time: [
+                                                        172800,
+                                                        165600,
+                                                        129600,
+                                                        86400
+                                                    ],
+                                                    timestamp: Math.floor(Date.now() / 1000),
+                                                    basetime: 172800
+                                                })
+                                            } catch (e) {
+                                                console.log("E");
+                                            }
 
-                                        await insertReminder({
-                                            _id: channel.id,
-                                            mention: `<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}>`,
-                                            channel: channel.id,
-                                            type: "match",
-                                            time: [
-                                                172800,
-                                                165600,
-                                                129600,
-                                                86400
-                                            ],
-                                            timestamp: Math.floor(Date.now() / 1000),
-                                            basetime: 172800
+                                            try{
+                                                let image = await matchcard(client, channel.id, [
+                                                    names.find(x => x.str === name1)!.id,
+                                                    names.find(x => x.str === name2)!.id
+                                                ]).catch();
+                                                await channel
+                                                    .send({
+                                                        content:`<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}> You have ${interaction.options!.getInteger("time")}h to complete this match. Contact a ref to begin, you may also split your match`,
+                                                        files:[
+                                                            image
+                                                        ]
+                                                    });
+                                            } catch (error) {
+                                                await console.log(`${channelstringname} no Match card`)
+                                                await console.log(error.stack)
+                                                await console.log(error.message)
+                                            }
+
                                         });
-                                        try{
-                                            let image = await matchcard(client, channel.id, [
-                                                names.find(x => x.str === name1)!.id,
-                                                names.find(x => x.str === name2)!.id
-                                            ]).catch();
-                                            await sleep(2)
-                                            await channel
-                                                .send({
-                                                    content:`<@${names.find(x => x.str === name1)!.id}> <@${names.find(x => x.str === name2)!.id}> You have ${args[1]}h to complete this match. Contact a ref to begin, you may also split your match`,
-                                                    files:[
-                                                        image
-                                                    ]
-                                                });
-                                        } catch (error) {
-                                            await message.channel.send(`${channelstringname} no Match card`)
-                                            await message.channel.send(error.stack)
-                                            await message.channel.send(error.message)
-                                        }
-
-                                    });
                                 }
                             });
                         }
                     }
                 }
             });
+            return interaction.editReply("Made all Match Channels");
         }
-        return message.reply("Made all channels");
-    }
+    },
+    slashCommandData:[
+        {
+            name: 'channelcreate',
+            description: 'Create either Match or Qualifier Channels.',
+            options: [
+                {
+                    name:"match",
+                    description:"Create match channels",
+                    type:"SUB_COMMAND",
+                    options: [
+                        {
+                            name:"round",
+                            description:"Which round is this",
+                            type:"INTEGER",
+                            required:true
+                        },
+                        {
+                            name:"time",
+                            description:"How long is the round",
+                            type:"INTEGER",
+                            required:true
+                        },
+                    ]
+                },
+                {
+                    name:"quals",
+                    description:"Create qualifier channels",
+                    type:"SUB_COMMAND",
+                    options: [
+                        {
+                            name:"portion",
+                            description:"Which Portion is this",
+                            type:"INTEGER",
+                            required:true
+                        },
+                        {
+                            name:"time",
+                            description:"How long is the round",
+                            type:"INTEGER",
+                            required:true
+                        },
+                    ]
+                }
+            ]
+        },
+    ],
+    slashCommandPermissions: [
+        commissionerDefaultSlashPermissions,
+        refDefaultSlashPermissions
+    ]
 };
 
 export const qualchannelcreate: Command = {
@@ -153,6 +378,7 @@ export const qualchannelcreate: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let time = parseInt(args[1]);
         if (!time) return message.channel.send("Please state how long this qualifier will be");
@@ -188,18 +414,19 @@ export const qualchannelcreate: Command = {
 
         }
 
-        return message.reply("Made all channels");
+        return message.reply("Made all Qualifier Channels");
     }
 };
 
 export const matchbracket: Command = {
-    name: "create-bracket",
+    name: "createbracket",
     description: "Will make bracket",
     group: "tournament-manager",
     owner: false,
     admins: false,
     mods: true,
-    slashCommand:false,
+    slashCommand:true,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         const cclient = challonge.createClient({
             apiKey: process.env.CHALLONGE
@@ -252,7 +479,77 @@ export const matchbracket: Command = {
                     .setTimestamp()
             ]
         });
-    }
+    },
+    async slashCommandFunction(interaction: CommandInteraction, client: Client) {
+        if(!interaction.isCommand()) return;
+
+        let matchid = interaction.options.getString("url")!.replace("https://challonge.com/", "");
+
+        const cclient = challonge.createClient({
+            apiKey: process.env.CHALLONGE
+        });
+
+        let matchlist: MatchList = await getDoc("config", "matchlist");
+
+        let randrun = Math.floor(Math.random() * 10) + 1;
+
+        while (randrun !== 0) {
+            for (let i = matchlist.users.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [
+                    matchlist.users[i],
+                    matchlist.users[j]
+                ] = [
+                    matchlist.users[j],
+                    matchlist.users[i]
+                ];
+            }
+            randrun--
+        }
+
+        for (let i = 0; i < matchlist.users.length; i++) {
+            let name = (await client.users.fetch(matchlist.users[i])).username;
+
+            cclient.participants.create({
+                id: matchid, participant: {
+                    name: name
+                }, callback: (err: any, data: any) => {
+                    console.log(err);
+                }
+            });
+        }
+
+        matchlist.url = `${matchid}`;
+
+        await updateDoc("config", "matchlist", matchlist);
+
+        await interaction.editReply({
+            embeds:[
+                new MessageEmbed()
+                    .setColor("#d7be26")
+                    .setTitle(`Meme Royale: ${interaction.options.getString("url")!}`)
+                    .setDescription(`Here's the link to the brackets\nhttps://www.challonge.com/${matchid}`)
+                    .setTimestamp()
+            ]
+        });
+    },
+    slashCommandData:[
+        {
+            name: 'create-bracket',
+            description: 'create match bracket!',
+            options: [
+                {
+                    name:"url",
+                    description:"What is the url?",
+                    required:true,
+                    type:"STRING"
+                }
+            ]
+        },
+    ],
+    slashCommandPermissions: [
+        commissionerDefaultSlashPermissions
+    ]
 };
 
 export const channeldelete: Command = {
@@ -262,7 +559,8 @@ export const channeldelete: Command = {
     owner: false,
     admins: false,
     mods: true,
-    slashCommand:false,
+    slashCommand:true,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let catchannels = [...message!.guild!.channels.cache.values()];
 
@@ -283,7 +581,50 @@ export const channeldelete: Command = {
 
             }
         }
-    }
+    },
+    async slashCommandFunction(interaction: CommandInteraction, client: Client) {
+        if(!interaction.isCommand()) return;
+        let guildChannels = [...interaction!.guild!.channels.cache.values()];
+
+        for (let channel of guildChannels) {
+
+            try {
+                if (channel.parent && channel.parent!.name?.toLowerCase() === interaction.options.getString("category")?.toLowerCase()) {
+                    await channel.delete();
+
+                    try{
+                        await deleteReminder(channel.id)
+                    } catch  {
+                        continue
+                    }
+                }
+
+            } catch {
+                continue
+            }
+
+            await interaction.editReply({
+                content: `Deleted channels in ${interaction.options.getString("category")}`
+            })
+        }
+    },
+    slashCommandData:[
+        {
+            name: 'deletechannels',
+            description: 'Delete channels in a category!',
+            options: [
+                {
+                    name:"category",
+                    description:"Which category?",
+                    required:true,
+                    type:"STRING"
+                }
+            ]
+        },
+    ],
+    slashCommandPermissions: [
+        commissionerDefaultSlashPermissions
+    ]
 };
 
 export default [

--- a/src/commands/tournament/index.ts
+++ b/src/commands/tournament/index.ts
@@ -13,6 +13,7 @@ export const cycle_restart: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let signup: Signups = await getDoc("config", "signups");
         signup.users = [];
@@ -37,6 +38,7 @@ export const create_groups: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
 
         if (isNaN(parseInt(args[0])) === true) {
@@ -100,6 +102,7 @@ export const view_groups: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let page: number = parseInt(args[0]) - 1 || 0;
         let ratings: QualList = await getDoc("config", "quallist");
@@ -173,6 +176,7 @@ export const templatecheck: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let list = await (await getTemplatedB()).list;
         let emotes = [

--- a/src/commands/tournament/signup.ts
+++ b/src/commands/tournament/signup.ts
@@ -11,6 +11,7 @@ export const signup: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let signup: Signups = await getDoc("config", "signups");
 
@@ -90,6 +91,7 @@ export const signup_manager: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let signup: Signups = await getDoc("config", "signups");
         let c = <TextChannel>await client.channels.fetch(message.guild!
@@ -117,11 +119,15 @@ export const signup_manager: Command = {
 
             await updateDoc("config", "signups", signup);
 
-            let signupRoles = await message.guild!.roles.cache.get("731574671723462757")!.members.map(m => m.user.id);
+            let signupRole = await message.guild!.roles.cache.get("731574671723462757")!.members.map(m => m.user.id);
 
-            for (let u of signupRoles) {
+            for (let u of signupRole) {
                 await client.users.fetch(u).then(async x => {
-                    await x.send("Signups now open. Check announcements.");
+                    try {
+                        await x.send("Signups now open. Check announcements.");
+                    } catch (e) {
+                        console.log(e.message)
+                    }
                 })
             }
 
@@ -201,6 +207,7 @@ export const unsignup: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let signup: Signups = await getDoc("config", "signups");
 
@@ -241,6 +248,7 @@ export const view_signup: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let page: number = parseInt(args[0]) || 1;
         let signup: Signups = await getDoc("config", "signups");

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -11,6 +11,7 @@ export const create_profile: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let imgurl = args[1] ? (client.users.cache.get(message.mentions.users.first()!.id)!.displayAvatarURL()) : message.author.displayAvatarURL();
 
@@ -52,6 +53,7 @@ export const profile_stats: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let user: Profile = await getProfile(args[0] ? (message.mentions.users.first()!.id) : message.author.id);//message.mentions?.users?.first()?.id
         // ||
@@ -98,6 +100,7 @@ export const disableDM: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let user: Profile = await getProfile(message.author.id);
         if (!user) {
@@ -133,6 +136,7 @@ export const profile_lb: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         let profiles = await getAllProfiles();
 
@@ -320,6 +324,7 @@ export const duel_stats: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let user: DuelProfile = await getDuelProfile((args[1] ? (message.mentions.users.first()!.id) : message.author.id), message.guild!.id);//message.mentions?.users?.first()?.id || args[0] ||
         let imgurl = args[1] ? (client.users.cache.get(message.mentions.users.first()!.id)!.displayAvatarURL()) : message.author.displayAvatarURL();
@@ -362,11 +367,12 @@ export const duel_stats_create: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let imgurl = args[1] ? (client.users.cache.get(message.mentions.users.first()!.id)!.displayAvatarURL()) : message.author.displayAvatarURL();
 
         if (await getDuelProfile(message.author.id, message.guild!.id)) {
-            return message.reply("That user profile does exist! Please do `!duel-stats` to check the user profile");
+            return message.reply("That user profile does exist! Please do `!duel -stats` to check the user profile");
         }
 
         else {
@@ -417,6 +423,7 @@ export const duel_lb: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:false,
     async execute(message: Message, client: Client, args: string[]) {
         let profiles = await getAllDuelProfiles(message.guild!.id);
 
@@ -466,8 +473,10 @@ export const duel_lb: Command = {
             });
         });
         forwards.on('collect', async () => {
+            console.log("A")
             m.reactions.cache.forEach(reaction => reaction.users.remove(message.author.id));
-            m.edit({
+            // [...m.reactions.cache.values()].forEach(reaction => reaction.users.remove(message.author.id));
+            await m.edit({
                 embeds:[
                     await makeDuelProfileEmbed(++page, client, profiles, symbol, message.author.id)
                 ]

--- a/src/commands/verification.ts
+++ b/src/commands/verification.ts
@@ -13,6 +13,7 @@ export const manualverify: Command = {
     admins: false,
     mods: true,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         if (!args[0]) {
             return message.reply("Please supply a name.");
@@ -41,16 +42,18 @@ export const manualverify: Command = {
 
 
         await message.mentions.users.first()!
-        .send({embeds:[
-                new MessageEmbed()
-                    .setDescription(`Remember to check\n` + `⇒ [#info](${linkObj[0]})\n` + `⇒ [#annoucements](${linkObj[1]})\n` + `⇒ [#rules](${linkObj[2]})\n` + `Also signup for both vote pings\nand signup pings in [#roles](${linkObj[3]})! Enjoy your stay!`)
-                    .setColor(`#${(await getConfig()).colour}`)
-                    .setTitle("Welcome to Meme Royale!")
-                    .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                        format: "webp",
-                        size: 512
-                    }))}`)
-            ]});
+            .send({
+                embeds: [
+                    new MessageEmbed()
+                        .setDescription(`Remember to check\n` + `⇒ [#info](${linkObj[0]})\n` + `⇒ [#annoucements](${linkObj[1]})\n` + `⇒ [#rules](${linkObj[2]})\n` + `Also signup for both vote pings\nand signup pings in [#roles](${linkObj[3]})! Enjoy your stay!`)
+                        .setColor(`#${(await getConfig()).colour}`)
+                        .setTitle("Welcome to Meme Royale!")
+                        .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                            format: "webp",
+                            size: 512
+                        }))}`)
+                ]
+            });
         await (<TextChannel>client.channels.cache.get(("722285800225505879"))!)
         .send(`A new contender entered the arena of Meme Royale. Welcome <@${message.mentions.users.first()!.id}>`);
     }
@@ -64,6 +67,7 @@ export const verify: Command = {
     admins: false,
     mods: false,
     slashCommand:false,
+    serverOnlyCommand:true,
     async execute(message: Message, client: Client, args: string[]) {
         const snoowrap = require('snoowrap');
 
@@ -140,10 +144,10 @@ export const verify: Command = {
                 )
                 .setColor(`#${(await getConfig()).colour}`)
                 .setTitle("Welcome to Meme Royale!")
-                .setFooter("MemeRoyale#3101", `${(client.users.cache.get("722303830368190485")!.displayAvatarURL({
-                    format: "webp",
-                    size: 512
-                }))}`)
+            .setFooter("MemeRoyale#3101", `${((await client.users.cache.get("722303830368190485"))!.displayAvatarURL({
+                format: "webp",
+                size: 512
+            }))}`)
 
 
             try{

--- a/src/listeners/index.ts
+++ b/src/listeners/index.ts
@@ -1,5 +1,5 @@
-import { ApplicationCommandData, Client, CommandInteraction, Intents } from "discord.js";
-import { connectToDB, getConfig } from "../db";
+import { ApplicationCommandData, Client, Collection, CommandInteraction, Intents, MessageAttachment, MessageReaction, TextChannel } from "discord.js";
+import { connectToDB, getConfig, getMatch, getProfile, getQual, getTemplatedB, getThemes, updateMatch, updateProfile, updateQual, updateTemplatedB, updateThemedB } from "../db";
 import { autoRunCommandLoop } from "../commands/jointcommands";
 import { cmd, prefix } from "../index";
 import { backgroundMatchLoop } from "../commands/match/background";
@@ -7,16 +7,40 @@ import { backgroundQualLoop } from "../commands/quals/background";
 import { backgroundExhibitionLoop } from "../commands/exhibition/background";
 import { backgroundReminderLoop } from "../commands/reminders";
 import { interactionButtonsCommand } from "./interactions/buttons";
+import { qual_winner } from "../commands/quals/util";
+import type { Profile } from "../types";
 
 export const client: Client = new Client({
-    intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGE_REACTIONS, Intents.FLAGS.DIRECT_MESSAGES],
-    allowedMentions: {parse: ['users', 'roles', 'everyone'], repliedUser: true},
-    partials: ["MESSAGE", "CHANNEL", "USER", "REACTION"],
+    intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MEMBERS,
+        Intents.FLAGS.GUILD_BANS,
+        Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS,
+        Intents.FLAGS.GUILD_INTEGRATIONS,
+        Intents.FLAGS.GUILD_WEBHOOKS,
+        Intents.FLAGS.GUILD_INVITES,
+        Intents.FLAGS.GUILD_VOICE_STATES,
+        Intents.FLAGS.GUILD_PRESENCES,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+        Intents.FLAGS.GUILD_MESSAGE_TYPING,
+        Intents.FLAGS.DIRECT_MESSAGES,
+        Intents.FLAGS.DIRECT_MESSAGE_REACTIONS,
+        Intents.FLAGS.DIRECT_MESSAGE_TYPING,
+    ],
+    allowedMentions: {
+        parse: ['users', 'roles', 'everyone'],
+        repliedUser: true
+    },
+    partials: ["USER", "CHANNEL", "GUILD_MEMBER", "MESSAGE", "REACTION"],
     restRequestTimeout: 90000,
 });
 
 client.once("ready", async () => {
     await connectToDB();
+    console.log(
+        "Intents: ", client.options.intents
+    )
 
     // let obj:Signups = {
     //     _id:"signups",
@@ -72,39 +96,39 @@ client.once("ready", async () => {
     console.log(`Logged in as ${client.user?.tag}\nPrefix is ${prefix}`);
     console.log(`In ${client.guilds.cache.size} servers\nTotal users is ${client.users.cache.size}\n\n`);
 
-    let data:ApplicationCommandData[] = [];
+    if (!process.env.dev) {
+        let data:ApplicationCommandData[] = [];
 
-    for(let c of cmd){
-        if(c.slashCommand) {
-            if(c.slashCommandData) {
-                if(data.length !== 0) data = data.concat(c.slashCommandData)
-                //@ts-ignore
-                else data.push(c.slashCommandData)
+        for(let c of cmd){
+            if(c.slashCommand) {
+                if(c.slashCommandData) {
+                    if(data.length !== 0) data = data.concat(c.slashCommandData)
+                    //@ts-ignore
+                    else data.push(c.slashCommandData)
+                }
             }
         }
-    }
 
-    // console.log(data.flat(1))
+        let setSlashCommands = await client.guilds.cache.get('719406444109103117')!.commands.set(data.flat(1));
 
-    let setSlashCommands = await client.guilds.cache.get('719406444109103117')!.commands.set(data.flat(1));
+        for(let s of setSlashCommands.values()) {
+            let command = cmd.find(c => {
+                if (typeof (c.aliases!) !== 'undefined' && c.aliases!.length > 0) {
+                    return (c.aliases?.includes(s.name.toLowerCase()!)
+                        || c.name.toLowerCase() === s.name.toLowerCase()!);
+                }
+                else {
+                    return c.name.toLowerCase() === s.name.toLowerCase()!;
+                }
+            });
 
-    for(let s of setSlashCommands.values()) {
-        let command = cmd.find(c => {
-            if (typeof (c.aliases!) !== 'undefined' && c.aliases!.length > 0) {
-                return (c.aliases?.includes(s.name.toLowerCase()!)
-                    || c.name.toLowerCase() === s.name.toLowerCase()!);
-            }
-            else {
-                return c.name.toLowerCase() === s.name.toLowerCase()!;
-            }
-        });
+            if(!command) continue;
+            if(!command.slashCommand) continue;
+            if(!command.slashCommandData) continue;
+            if(!command.slashCommandPermissions) continue;
 
-        if(!command) continue;
-        if(!command.slashCommand) continue;
-        if(!command.slashCommandData) continue;
-        if(!command.slashCommandPermissions) continue;
-
-        await s.permissions.add({permissions: command.slashCommandPermissions})
+            await s.permissions.add({permissions: command.slashCommandPermissions})
+        }
     }
 
     await client.user!.setActivity(`${((await getConfig()).status)}`);
@@ -126,6 +150,313 @@ client.on('interactionCreate', async interaction => {
     if(interaction.isCommand()) await interactionSlashCommand(interaction, client);
 });
 
+client.on("error", async (error) => {
+    console.log(error.stack)
+})
+
+client.on("messageReactionAdd", async (messageReaction, user) => {
+    if (user.id === "722303830368190485") return;
+    if (user.bot) return;
+    if(!messageReaction.emoji.name) return;
+
+    if (messageReaction.partial === true) messageReaction = await messageReaction.fetch();
+    if (messageReaction.message.partial === true) await messageReaction.message.fetch(true);
+    if (user.partial === true) user = await user.fetch(true);
+
+    if (messageReaction.emoji.name === "1️⃣" && await getMatch(messageReaction.message.channel.id)) {
+        await messageReaction.users.remove(user.id);
+        let m = await getMatch(messageReaction.message.channel.id);
+        let p = await getProfile(user.id);
+        if (!m) return;
+
+        if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
+        if (m.p1.voters.includes(user.id)) {
+            if (p && p.voteDM && !m.exhibition) await user.send("Voting for the same meme is not allowed.");
+            return;
+        }
+        m.p1.voters.push(user.id);
+        m.p1.votes += 1;
+
+        if (m.p2.voters.includes(user.id)) {
+            m.p2.voters.splice(m.p2.voters.indexOf(user.id), 1);
+            m.p2.votes -= 1;
+        }
+
+        await updateMatch(m);
+
+        if(p && p.voteDM && !m.exhibition) {
+            await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
+        }
+
+        return;
+    }
+
+    if (messageReaction.emoji.name === "2️⃣" && await getMatch(messageReaction.message.channel.id)) {
+        console.log("Check")
+        await messageReaction.users.remove(user.id);
+        let m = await getMatch(messageReaction.message.channel.id);
+        let p = await getProfile(user.id);
+        if (!m) return;
+        console.log("Check")
+
+        if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
+        if (m.p2.voters.includes(user.id)) {
+            if (p && p.voteDM && !m.exhibition) await user.send("Voting for the same meme is not allowed.");
+            return;
+        }
+
+        console.log("Check")
+        m.p2.voters.push(user.id);
+        m.p2.votes += 1;
+
+        if (m.p1.voters.includes(user.id)) {
+            m.p1.voters.splice(m.p1.voters.indexOf(user.id), 1);
+            m.p1.votes -= 1;
+        }
+
+        await updateMatch(m);
+        console.log("Check")
+        console.log("Check")
+
+        if (p && p.voteDM && !m.exhibition) {
+            await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
+        }
+
+        console.log("Check")
+
+        return;
+    }
+
+    if ([
+        "1️⃣",
+        "2️⃣",
+        "3️⃣",
+        "4️⃣",
+        "5️⃣",
+        "6️⃣"
+    ].includes(messageReaction.emoji.name!) && await getQual(messageReaction.message.channel.id)) {
+        await messageReaction.users.remove(user.id);
+        let q = await getQual(messageReaction.message.channel.id);
+        if (!q) return;
+
+        //if(q.players.some(x => x.userid === user.id)) return user.send("Can't vote in your own qualifer");
+
+        let pos = [
+            "1️⃣",
+            "2️⃣",
+            "3️⃣",
+            "4️⃣",
+            "5️⃣",
+            "6️⃣"
+        ].indexOf(messageReaction.emoji.name!);
+        if (q.players.map(a => a.userid).includes(user.id)) return user.send("Can't vote in your own match");
+        let p = await getProfile(user.id);
+
+        if (q.players[pos].votes.includes(user.id) === false) {
+            if (q.players.filter(y => y.votes.includes(user.id)).length === 2) {
+                if (p && p.voteDM) await user.send("You can only vote for 2 memes. " +
+                    "Please hit recycle button to reset your votes");
+                return;
+            }
+
+            if (q.players[pos].failed === true) {
+                if (p && p.voteDM) await user.send("You can't vote for a user who failed");
+                return;
+            }
+
+            q.players[pos].votes.push(user.id);
+
+            await updateQual(q);
+
+            if (p && p.voteDM) await user
+                .send(`You have voted for Meme #${pos + 1} in <#${messageReaction.message.channel.id}>`);
+            return;
+        }
+        else {
+            if (p && p.voteDM) await user.send("You have already voted for this meme");
+            return;
+        }
+
+    }
+
+    if (messageReaction.emoji.name === "♻️") {
+        await messageReaction.users.remove(user.id);
+        let q = await getQual(messageReaction.message.channel.id);
+        if (!q) return;
+
+        q.players.forEach(function (v) {
+            if (v.votes.includes(user.id)) {
+                let pos = q.players.indexOf(v);
+                v.votes = v.votes.splice(pos, 1);
+            }
+        });
+
+        await updateQual(q);
+        let p = await getProfile(user.id);
+        if (p && p.voteDM) await user.send(`All votes in <#${messageReaction.message.channel.id}> reset`);
+        return;
+    }
+
+    if (messageReaction.emoji.name === "🅰️") {
+        await messageReaction.users.remove(user.id);
+        let m = await getMatch(messageReaction.message.channel.id);
+        if (!m) return;
+
+        if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
+            .members.cache.get(user.id)!.roles.cache
+            .find(x => x.name.toLowerCase() === "referee") && m.p1.userid !== user.id) {
+            await messageReaction.users.remove(user.id);
+            return user.send("No.");
+        }
+
+        await messageReaction.users.remove(user.id);
+
+        if(m.p1.donesplit === true) return;
+
+        return cmd.find(c => c.name.toLowerCase() === "start-split")
+            ?.execute(await messageReaction.message.fetch(), client, [m.p1.userid]);
+    }
+
+    if (messageReaction.emoji.name === "🅱️") {
+        await messageReaction.users.remove(user.id);
+        let m = await getMatch(messageReaction.message.channel.id);
+        if (!m) return;
+
+        if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
+            .members.cache.get(user.id)!.roles.cache
+            .find(x => x.name.toLowerCase() === "referee") && m.p2.userid !== user.id) {
+            await messageReaction.users.remove(user.id);
+            return user.send("No.");
+        }
+        await messageReaction.users.remove(user.id);
+
+        if(m.p2.donesplit === true) return;
+
+        return cmd.find(c => c.name.toLowerCase() === "start-split")
+            ?.execute(await messageReaction.message.fetch(), client, [m.p2.userid]);
+    }
+
+    if ([
+        "🇦",
+        "🇧",
+        "🇨",
+        "🇩",
+        "🇪",
+        "🇫"
+    ].includes(messageReaction.emoji.name!)) {
+        await messageReaction.users.remove(user.id);
+        let m = await getQual(messageReaction.message.channel.id);
+        if (!m) return;
+        let pos = [
+            "🇦",
+            "🇧",
+            "🇨",
+            "🇩",
+            "🇪",
+            "🇫"
+        ].indexOf(messageReaction.emoji.name!);
+        if ((m.players[pos].userid !== user.id) && !user.client.guilds.cache
+            .get(messageReaction.message.guild!.id)!
+            .members.cache.get(user.id)!.roles.cache
+            .find(x => x.name.toLowerCase() === "referee")) {
+            return user.send("No.");
+        }
+        if (m.players[pos].memedone || m.players[pos].failed || m.players[pos].split) return;
+        cmd.find(c => c.name.toLowerCase() === "start-qual")
+            ?.execute(await messageReaction.message.fetch(), client, [m.players[pos].userid]);
+    }
+
+    if (messageReaction.emoji.name === "🗳️") {
+        await cmd.find(c => c.name.toLowerCase() === "signup")?.execute(await messageReaction.message.fetch(), client, [user.id]);
+        await messageReaction.users.remove(user.id);
+    }
+
+    if (messageReaction.emoji.name === "👌") {
+        if (!user.client.guilds.cache
+            .get(messageReaction.message.guild!.id)!
+            .members.cache.get(user.id)!
+            .roles.cache.has("719936221572235295")) {
+            return;
+        }
+
+        let channel = <TextChannel>await messageReaction.message.channel.fetch();
+        let em = (await channel.messages.fetch(messageReaction.message.id)).embeds[0]!;
+        let iter = 0;
+        let key = [];
+        for (let f of em.fields) {
+            key.push(`${f.value.match(/\d+/g)![1]}`);
+            iter += 1;
+            if (iter === 2) {
+                await messageReaction.remove();
+                break;
+            }
+        }
+        await qual_winner.execute(await messageReaction.message.fetch(), client, key, "2", [user.id]);
+    }
+
+    if (messageReaction.emoji.name === "🏁") {
+        // let voteCollection: Collection<string, MessageReaction>;
+
+        let voteCollection: Collection<string, MessageReaction> = await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
+            .then(msg => msg.reactions.cache);
+
+        let totalVotes = voteCollection!.first()!.count!;
+
+        if (totalVotes >= 3) {
+            let id: Profile | undefined;
+            id = await getProfile(await messageReaction.message.embeds[0].description!);
+            //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
+            if (await messageReaction.message.embeds[0].image?.url) {
+                let e = await getTemplatedB();
+                e.list.push(await messageReaction.message.embeds[0].image!.url);
+                await updateTemplatedB(e.list);
+
+                if (id) {
+                    id.points += 2;
+                    await updateProfile(id);
+                }
+
+                let attach = new MessageAttachment(messageReaction.message.embeds[0].image!.url);
+
+                (<TextChannel>await client.channels.fetch("724827952390340648")).send({content: "New template:", files:[attach]});
+            }
+            else if (await messageReaction.message.embeds[0].fields) {
+                let obj = await getThemes();
+
+                obj.list.push(messageReaction.message.embeds[0].fields[1].value);
+
+                await updateThemedB({
+                    _id: "themelist", list: obj.list
+                });
+
+                if (id) {
+                    id.points += 2;
+                    await updateProfile(id);
+                }
+
+                await (<TextChannel>await client.channels.fetch("724837977838059560")).send("New Theme: " + `${messageReaction.message.embeds[0].fields[1].value}`);
+            }
+            await messageReaction.message.delete();
+        }
+    }
+
+    if (messageReaction.emoji.name === "🗡️") {
+        let voteCollection: Collection<string, MessageReaction>;
+
+        await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
+            .then(msg => voteCollection = msg.reactions.cache);
+
+        let totalVotes = voteCollection!.first()!.count!;
+
+        if (totalVotes === 3) {
+            //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
+            await messageReaction.message.delete();
+        }
+    }
+});
+
+// client.ws.on("MESSAGE_REACTION_ADD", console.log)
+
 async function interactionSlashCommand(interaction: CommandInteraction, client: Client) {
     // let command = cmd.find(c => {
     //     return c.name.toLowerCase() === interaction.commandName.toLowerCase();
@@ -143,7 +474,7 @@ async function interactionSlashCommand(interaction: CommandInteraction, client: 
 
     if(command && command.slashCommand){
         try {
-            await interaction.deferReply({ ephemeral: true });
+            await interaction.deferReply({ ephemeral: false });
             // @ts-ignore
             await command.slashCommandFunction(interaction, client)
         } catch(err) {

--- a/src/listeners/reactions.ts
+++ b/src/listeners/reactions.ts
@@ -1,297 +1,306 @@
-import { client } from "./index";
-import { getMatch, getProfile, getQual, getTemplatedB, getThemes, updateMatch, updateProfile, updateQual, updateTemplatedB, updateThemedB } from "../db";
-import { cmd } from "../index";
-import { Collection, MessageAttachment, MessageReaction, TextChannel } from "discord.js";
-import { qual_winner } from "../commands/quals/util";
-import type { Profile } from "../types";
-
-client.on("messageReactionAdd", async (messageReaction, user) => {
-    if (user.id === "722303830368190485") return;
-    if (user.bot) return;
-    if(!messageReaction.emoji.name) return;
-
-    if (messageReaction.partial === true) await messageReaction.fetch();
-    if (messageReaction.message.partial === true) await messageReaction.message.fetch();
-
-    if (messageReaction.emoji.name === "1️⃣" && await getMatch(messageReaction.message.channel.id)) {
-        let m = await getMatch(messageReaction.message.channel.id);
-        let p = await getProfile(user.id);
-        if (!m) return;
-        await messageReaction.users.remove(user.id);
-        if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
-        if (m.p1.voters.includes(user.id)) {
-            if (p && p.voteDM) await user.send("Voting for the same meme is not allowed.");
-            return;
-        }
-        m.p1.voters.push(user.id);
-        m.p1.votes += 1;
-
-        if (m.p2.voters.includes(user.id)) {
-            m.p2.voters.splice(m.p2.voters.indexOf(user.id), 1);
-            m.p2.votes -= 1;
-        }
-
-        await updateMatch(m);
-
-        if(p && p.voteDM) {
-            await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
-        }
-
-        return;
-    }
-
-    if (messageReaction.emoji.name === "2️⃣" && await getMatch(messageReaction.message.channel.id)) {
-        let m = await getMatch(messageReaction.message.channel.id);
-        let p = await getProfile(user.id);
-        if (!m) return;
-        await messageReaction.users.remove(user.id);
-        if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
-        if (m.p2.voters.includes(user.id)) {
-            if (p && p.voteDM) await user.send("Voting for the same meme is not allowed.");
-            return;
-        }
-        m.p2.voters.push(user.id);
-        m.p2.votes += 1;
-
-        if (m.p1.voters.includes(user.id)) {
-            m.p1.voters.splice(m.p1.voters.indexOf(user.id), 1);
-            m.p1.votes -= 1;
-        }
-
-        await updateMatch(m);
-
-
-        if (p && p.voteDM) {
-            await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
-        }
-
-        return;
-    }
-
-    if ([
-        "1️⃣",
-        "2️⃣",
-        "3️⃣",
-        "4️⃣",
-        "5️⃣",
-        "6️⃣"
-    ].includes(messageReaction.emoji.name) && await getQual(messageReaction.message.channel.id)) {
-        await messageReaction.users.remove(user.id);
-        let q = await getQual(messageReaction.message.channel.id);
-        if (!q) return;
-
-        //if(q.players.some(x => x.userid === user.id)) return user.send("Can't vote in your own qualifer");
-
-        let pos = [
-            "1️⃣",
-            "2️⃣",
-            "3️⃣",
-            "4️⃣",
-            "5️⃣",
-            "6️⃣"
-        ].indexOf(messageReaction.emoji.name);
-        if (q.players.map(a => a.userid).includes(user.id)) return user.send("Can't vote in your own match");
-        let p = await getProfile(user.id);
-
-        if (q.players[pos].votes.includes(user.id) === false) {
-            if (q.players.filter(y => y.votes.includes(user.id)).length === 2) {
-                if (p && p.voteDM) await user.send("You can only vote for 2 memes. " +
-                    "Please hit recycle button to reset your votes");
-                return;
-            }
-
-            if (q.players[pos].failed === true) {
-                if (p && p.voteDM) await user.send("You can't vote for a user who failed");
-                return;
-            }
-
-            q.players[pos].votes.push(user.id);
-
-            await updateQual(q);
-
-            if (p && p.voteDM) await user
-                .send(`You have voted for Meme #${pos + 1} in <#${messageReaction.message.channel.id}>`);
-            return;
-        }
-        else {
-            if (p && p.voteDM) await user.send("You have already voted for this meme");
-            return;
-        }
-
-    }
-
-    if (messageReaction.emoji.name === "♻️") {
-        await messageReaction.users.remove(user.id);
-        let q = await getQual(messageReaction.message.channel.id);
-        if (!q) return;
-
-        q.players.forEach(function (v) {
-            if (v.votes.includes(user.id)) {
-                let pos = q.players.indexOf(v);
-                v.votes = v.votes.splice(pos, 1);
-            }
-        });
-
-        await updateQual(q);
-        let p = await getProfile(user.id);
-        if (p && p.voteDM) await user.send(`All votes in <#${messageReaction.message.channel.id}> reset`);
-        return;
-    }
-
-    if (messageReaction.emoji.name === "🅰️") {
-        await messageReaction.users.remove(user.id);
-        let m = await getMatch(messageReaction.message.channel.id);
-        if (!m) return;
-
-        if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
-            .members.cache.get(user.id)!.roles.cache
-            .find(x => x.name.toLowerCase() === "referee") && m.p1.userid !== user.id) {
-            await messageReaction.users.remove(user.id);
-            return user.send("No.");
-        }
-
-        await messageReaction.users.remove(user.id);
-
-        if(m.p1.donesplit === true) return;
-
-        return cmd.find(c => c.name.toLowerCase() === "start-split")
-            ?.execute(await messageReaction.message.fetch(), client, [m.p1.userid]);
-    }
-
-    if (messageReaction.emoji.name === "🅱️") {
-        await messageReaction.users.remove(user.id);
-        let m = await getMatch(messageReaction.message.channel.id);
-        if (!m) return;
-
-        if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
-            .members.cache.get(user.id)!.roles.cache
-            .find(x => x.name.toLowerCase() === "referee") && m.p2.userid !== user.id) {
-            await messageReaction.users.remove(user.id);
-            return user.send("No.");
-        }
-        await messageReaction.users.remove(user.id);
-
-        if(m.p2.donesplit === true) return;
-
-        return cmd.find(c => c.name.toLowerCase() === "start-split")
-            ?.execute(await messageReaction.message.fetch(), client, [m.p2.userid]);
-    }
-
-    if ([
-        "🇦",
-        "🇧",
-        "🇨",
-        "🇩",
-        "🇪",
-        "🇫"
-    ].includes(messageReaction.emoji.name)) {
-        await messageReaction.users.remove(user.id);
-        let m = await getQual(messageReaction.message.channel.id);
-        if (!m) return;
-        let pos = [
-            "🇦",
-            "🇧",
-            "🇨",
-            "🇩",
-            "🇪",
-            "🇫"
-        ].indexOf(messageReaction.emoji.name);
-        if ((m.players[pos].userid !== user.id) && !user.client.guilds.cache
-            .get(messageReaction.message.guild!.id)!
-            .members.cache.get(user.id)!.roles.cache
-            .find(x => x.name.toLowerCase() === "referee")) {
-            return user.send("No.");
-        }
-        if (m.players[pos].memedone || m.players[pos].failed) return;
-        cmd.find(c => c.name.toLowerCase() === "start-qual")
-            ?.execute(await messageReaction.message.fetch(), client, [m.players[pos].userid]);
-    }
-
-    if (messageReaction.emoji.name === "🗳️") {
-        await cmd.find(c => c.name.toLowerCase() === "signup")?.execute(await messageReaction.message.fetch(), client, [user.id]);
-        await messageReaction.users.remove(user.id);
-    }
-
-    if (messageReaction.emoji.name === "👌") {
-        if (!user.client.guilds.cache
-            .get(messageReaction.message.guild!.id)!
-            .members.cache.get(user.id)!
-            .roles.cache.has("719936221572235295")) {
-            return;
-        }
-
-        let channel = <TextChannel>await messageReaction.message.channel.fetch();
-        let em = (await channel.messages.fetch(messageReaction.message.id)).embeds[0]!;
-        let iter = 0;
-        let key = [];
-        for (let f of em.fields) {
-            key.push(`${f.value.match(/\d+/g)![1]}`);
-            iter += 1;
-            if (iter === 2) {
-                await messageReaction.remove();
-                break;
-            }
-        }
-        await qual_winner.execute(await messageReaction.message.fetch(), client, key, "2", [user.id]);
-    }
-
-    if (messageReaction.emoji.name === "🏁") {
-        // let voteCollection: Collection<string, MessageReaction>;
-
-        let voteCollection: Collection<string, MessageReaction> = await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
-            .then(msg => msg.reactions.cache);
-
-        let totalVotes = voteCollection!.first()!.count!;
-
-        if (totalVotes >= 3) {
-            let id: Profile | undefined;
-            id = await getProfile(await messageReaction.message.embeds[0].description!);
-            //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
-            if (await messageReaction.message.embeds[0].image?.url) {
-                let e = await getTemplatedB();
-                e.list.push(await messageReaction.message.embeds[0].image!.url);
-                await updateTemplatedB(e.list);
-
-                if (id) {
-                    id.points += 2;
-                    await updateProfile(id);
-                }
-
-                let attach = new MessageAttachment(messageReaction.message.embeds[0].image!.url);
-
-                (<TextChannel>await client.channels.fetch("724827952390340648")).send({content: "New template:", files:[attach]});
-            }
-            else if (await messageReaction.message.embeds[0].fields) {
-                let obj = await getThemes();
-
-                obj.list.push(messageReaction.message.embeds[0].fields[1].value);
-
-                await updateThemedB({
-                    _id: "themelist", list: obj.list
-                });
-
-                if (id) {
-                    id.points += 2;
-                    await updateProfile(id);
-                }
-
-                await (<TextChannel>await client.channels.fetch("724837977838059560")).send("New Theme: " + `${messageReaction.message.embeds[0].fields[1].value}`);
-            }
-            await messageReaction.message.delete();
-        }
-    }
-
-    if (messageReaction.emoji.name === "🗡️") {
-        let voteCollection: Collection<string, MessageReaction>;
-
-        await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
-            .then(msg => voteCollection = msg.reactions.cache);
-
-        let totalVotes = voteCollection!.first()!.count!;
-
-        if (totalVotes === 3) {
-            //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
-            await messageReaction.message.delete();
-        }
-    }
-});
+// import { client } from "./index";
+// import { getMatch, getProfile, getQual, getTemplatedB, getThemes, updateMatch, updateProfile, updateQual, updateTemplatedB, updateThemedB } from "../db";
+// import { cmd } from "../index";
+// import { Collection, MessageAttachment, MessageReaction, TextChannel } from "discord.js";
+// import { qual_winner } from "../commands/quals/util";
+// import type { Profile } from "../types";
+//
+// client.on("messageReactionAdd", async (messageReaction, user) => {
+//     console.log("AAA")
+//     if (user.id === "722303830368190485") return;
+//     if (user.bot) return;
+//     if(!messageReaction.emoji.name) return;
+//     console.log("AAA")
+//
+//     if (messageReaction.partial === true) messageReaction = await messageReaction.fetch();
+//     if (messageReaction.message.partial === true) await messageReaction.message.fetch(true);
+//     if (user.partial === true) user = await user.fetch(true);
+//
+//     if (messageReaction.emoji.name === "1️⃣" && await getMatch(messageReaction.message.channel.id)) {
+//         let m = await getMatch(messageReaction.message.channel.id);
+//         let p = await getProfile(user.id);
+//         if (!m) return;
+//
+//         if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
+//         if (m.p1.voters.includes(user.id)) {
+//             if (p && p.voteDM && !m.exhibition) await user.send("Voting for the same meme is not allowed.");
+//             return;
+//         }
+//         m.p1.voters.push(user.id);
+//         m.p1.votes += 1;
+//
+//         if (m.p2.voters.includes(user.id)) {
+//             m.p2.voters.splice(m.p2.voters.indexOf(user.id), 1);
+//             m.p2.votes -= 1;
+//         }
+//
+//         await updateMatch(m);
+//         await (await messageReaction.fetch()).users.remove(user.id)
+//
+//         if(p && p.voteDM && !m.exhibition) {
+//             await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
+//         }
+//
+//         return;
+//     }
+//
+//     if (messageReaction.emoji.name === "2️⃣" && await getMatch(messageReaction.message.channel.id)) {
+//         let m = await getMatch(messageReaction.message.channel.id);
+//         let p = await getProfile(user.id);
+//         if (!m) return;
+//
+//         if (m.p1.userid === user.id || m.p2.userid === user.id) return user.send("Can't vote in your own match");
+//         if (m.p2.voters.includes(user.id)) {
+//             if (p && p.voteDM && !m.exhibition) await user.send("Voting for the same meme is not allowed.");
+//             return;
+//         }
+//         m.p2.voters.push(user.id);
+//         m.p2.votes += 1;
+//
+//         if (m.p1.voters.includes(user.id)) {
+//             m.p1.voters.splice(m.p1.voters.indexOf(user.id), 1);
+//             m.p1.votes -= 1;
+//         }
+//
+//         await updateMatch(m);
+//         console.log(user)
+//         await messageReaction.users.remove(user.id);
+//
+//         if (p && p.voteDM && !m.exhibition) {
+//             await user.send(`Vote counted for Player 1's memes in <#${m._id}>. You gained 2 points for voting`);
+//         }
+//
+//         return;
+//     }
+//
+//     if ([
+//         "1️⃣",
+//         "2️⃣",
+//         "3️⃣",
+//         "4️⃣",
+//         "5️⃣",
+//         "6️⃣"
+//     ].includes(messageReaction.emoji.name!) && await getQual(messageReaction.message.channel.id)) {
+//         await messageReaction.users.remove(user.id);
+//         let q = await getQual(messageReaction.message.channel.id);
+//         if (!q) return;
+//
+//         //if(q.players.some(x => x.userid === user.id)) return user.send("Can't vote in your own qualifer");
+//
+//         let pos = [
+//             "1️⃣",
+//             "2️⃣",
+//             "3️⃣",
+//             "4️⃣",
+//             "5️⃣",
+//             "6️⃣"
+//         ].indexOf(messageReaction.emoji.name!);
+//         if (q.players.map(a => a.userid).includes(user.id)) return user.send("Can't vote in your own match");
+//         let p = await getProfile(user.id);
+//
+//         if (q.players[pos].votes.includes(user.id) === false) {
+//             if (q.players.filter(y => y.votes.includes(user.id)).length === 2) {
+//                 if (p && p.voteDM) await user.send("You can only vote for 2 memes. " +
+//                     "Please hit recycle button to reset your votes");
+//                 return;
+//             }
+//
+//             if (q.players[pos].failed === true) {
+//                 if (p && p.voteDM) await user.send("You can't vote for a user who failed");
+//                 return;
+//             }
+//
+//             q.players[pos].votes.push(user.id);
+//
+//             await updateQual(q);
+//
+//             if (p && p.voteDM) await user
+//                 .send(`You have voted for Meme #${pos + 1} in <#${messageReaction.message.channel.id}>`);
+//             return;
+//         }
+//         else {
+//             if (p && p.voteDM) await user.send("You have already voted for this meme");
+//             return;
+//         }
+//
+//     }
+//
+//     if (messageReaction.emoji.name === "♻️") {
+//         await messageReaction.users.remove(user.id);
+//         let q = await getQual(messageReaction.message.channel.id);
+//         if (!q) return;
+//
+//         q.players.forEach(function (v) {
+//             if (v.votes.includes(user.id)) {
+//                 let pos = q.players.indexOf(v);
+//                 v.votes = v.votes.splice(pos, 1);
+//             }
+//         });
+//
+//         await updateQual(q);
+//         let p = await getProfile(user.id);
+//         if (p && p.voteDM) await user.send(`All votes in <#${messageReaction.message.channel.id}> reset`);
+//         return;
+//     }
+//
+//     if (messageReaction.emoji.name === "🅰️") {
+//         await messageReaction.users.remove(user.id);
+//         let m = await getMatch(messageReaction.message.channel.id);
+//         if (!m) return;
+//
+//         if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
+//             .members.cache.get(user.id)!.roles.cache
+//             .find(x => x.name.toLowerCase() === "referee") && m.p1.userid !== user.id) {
+//             await messageReaction.users.remove(user.id);
+//             return user.send("No.");
+//         }
+//
+//         await messageReaction.users.remove(user.id);
+//
+//         if(m.p1.donesplit === true) return;
+//
+//         return cmd.find(c => c.name.toLowerCase() === "start-split")
+//             ?.execute(await messageReaction.message.fetch(), client, [m.p1.userid]);
+//     }
+//
+//     if (messageReaction.emoji.name === "🅱️") {
+//         await messageReaction.users.remove(user.id);
+//         let m = await getMatch(messageReaction.message.channel.id);
+//         if (!m) return;
+//
+//         if (!user.client.guilds.cache.get(messageReaction.message.guild!.id)!
+//             .members.cache.get(user.id)!.roles.cache
+//             .find(x => x.name.toLowerCase() === "referee") && m.p2.userid !== user.id) {
+//             await messageReaction.users.remove(user.id);
+//             return user.send("No.");
+//         }
+//         await messageReaction.users.remove(user.id);
+//
+//         if(m.p2.donesplit === true) return;
+//
+//         return cmd.find(c => c.name.toLowerCase() === "start-split")
+//             ?.execute(await messageReaction.message.fetch(), client, [m.p2.userid]);
+//     }
+//
+//     if ([
+//         "🇦",
+//         "🇧",
+//         "🇨",
+//         "🇩",
+//         "🇪",
+//         "🇫"
+//     ].includes(messageReaction.emoji.name!)) {
+//         await messageReaction.users.remove(user.id);
+//         let m = await getQual(messageReaction.message.channel.id);
+//         if (!m) return;
+//         let pos = [
+//             "🇦",
+//             "🇧",
+//             "🇨",
+//             "🇩",
+//             "🇪",
+//             "🇫"
+//         ].indexOf(messageReaction.emoji.name!);
+//         if ((m.players[pos].userid !== user.id) && !user.client.guilds.cache
+//             .get(messageReaction.message.guild!.id)!
+//             .members.cache.get(user.id)!.roles.cache
+//             .find(x => x.name.toLowerCase() === "referee")) {
+//             return user.send("No.");
+//         }
+//         if (m.players[pos].memedone || m.players[pos].failed) return;
+//         cmd.find(c => c.name.toLowerCase() === "start-qual")
+//             ?.execute(await messageReaction.message.fetch(), client, [m.players[pos].userid]);
+//     }
+//
+//     if (messageReaction.emoji.name === "🗳️") {
+//         await cmd.find(c => c.name.toLowerCase() === "signup")?.execute(await messageReaction.message.fetch(), client, [user.id]);
+//         await messageReaction.users.remove(user.id);
+//     }
+//
+//     if (messageReaction.emoji.name === "👌") {
+//         if (!user.client.guilds.cache
+//             .get(messageReaction.message.guild!.id)!
+//             .members.cache.get(user.id)!
+//             .roles.cache.has("719936221572235295")) {
+//             return;
+//         }
+//
+//         let channel = <TextChannel>await messageReaction.message.channel.fetch();
+//         let em = (await channel.messages.fetch(messageReaction.message.id)).embeds[0]!;
+//         let iter = 0;
+//         let key = [];
+//         for (let f of em.fields) {
+//             key.push(`${f.value.match(/\d+/g)![1]}`);
+//             iter += 1;
+//             if (iter === 2) {
+//                 await messageReaction.remove();
+//                 break;
+//             }
+//         }
+//         await qual_winner.execute(await messageReaction.message.fetch(), client, key, "2", [user.id]);
+//     }
+//
+//     if (messageReaction.emoji.name === "🏁") {
+//         // let voteCollection: Collection<string, MessageReaction>;
+//
+//         let voteCollection: Collection<string, MessageReaction> = await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
+//             .then(msg => msg.reactions.cache);
+//
+//         let totalVotes = voteCollection!.first()!.count!;
+//
+//         if (totalVotes >= 3) {
+//             let id: Profile | undefined;
+//             id = await getProfile(await messageReaction.message.embeds[0].description!);
+//             //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
+//             if (await messageReaction.message.embeds[0].image?.url) {
+//                 let e = await getTemplatedB();
+//                 e.list.push(await messageReaction.message.embeds[0].image!.url);
+//                 await updateTemplatedB(e.list);
+//
+//                 if (id) {
+//                     id.points += 2;
+//                     await updateProfile(id);
+//                 }
+//
+//                 let attach = new MessageAttachment(messageReaction.message.embeds[0].image!.url);
+//
+//                 (<TextChannel>await client.channels.fetch("724827952390340648")).send({content: "New template:", files:[attach]});
+//             }
+//             else if (await messageReaction.message.embeds[0].fields) {
+//                 let obj = await getThemes();
+//
+//                 obj.list.push(messageReaction.message.embeds[0].fields[1].value);
+//
+//                 await updateThemedB({
+//                     _id: "themelist", list: obj.list
+//                 });
+//
+//                 if (id) {
+//                     id.points += 2;
+//                     await updateProfile(id);
+//                 }
+//
+//                 await (<TextChannel>await client.channels.fetch("724837977838059560")).send("New Theme: " + `${messageReaction.message.embeds[0].fields[1].value}`);
+//             }
+//             await messageReaction.message.delete();
+//         }
+//     }
+//
+//     if (messageReaction.emoji.name === "🗡️") {
+//         let voteCollection: Collection<string, MessageReaction>;
+//
+//         await messageReaction.message.channel.messages.fetch(messageReaction.message.id)
+//             .then(msg => voteCollection = msg.reactions.cache);
+//
+//         let totalVotes = voteCollection!.first()!.count!;
+//
+//         if (totalVotes === 3) {
+//             //await tempccc.send(await messageReaction.message.embeds[0].image?.url)
+//             await messageReaction.message.delete();
+//         }
+//     }
+// });
+//
+// client.ws.on("MESSAGE_REACTION_ADD", console.log)
+// client.ws.on("MESSAGE_REACTION_REMOVE", console.log)
+// client.ws.on("MESSAGE_CREATE", console.log)

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Command {
     admins: boolean;
     mods: boolean;
     slashCommand:boolean;
+    serverOnlyCommand:boolean;
 
     // Making `args` optional
     execute(message: Message, client: Client, args?: string[], ownerID?: string, silentargs?: string[]): Promise<any>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
       "declaration": false,
       /* Generates corresponding '.d.ts' file. */
       "declarationMap": false,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-      // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-      // "outFile": "./",                       /* Concatenate and emit output to single file. */
+      "sourceMap": true,                     /* Generates corresponding '.map' file. */
+      // "outFile": "./minify/index.min.js",                       /* Concatenate and emit output to single file. */
       "outDir": "./dist/",
       /* Redirect output structure to the directory. */
       // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
Made create channel command work for both quals and matches

Added Server only commands, mainly for duel exporting


Specifying Node and NPM Version


Disabled bot wide commands don't send reply anymore


Added more intents


Hot fix


Hot fix 2


moved reaction event to index ts in listeners


Wrong token


Editing embed doesn't edit it, so new variable called temps


Theme no show


Can't spam start qual portions no more

- Added try and catch to Signup role ping
- Fixed empty template crap in Matches
qualifier channel topic can now include qualifierround


rqw


rqw error


AAA


error command log, and search is fixed for matches

